### PR TITLE
Added 10 second snooze duration for when slider is set to zero

### DIFF
--- a/app/src/main/res/values/values.xml
+++ b/app/src/main/res/values/values.xml
@@ -1,6 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- in milliseconds -->
+    <integer name="zero_snooze_duration">10000</integer>
+
+    <!-- Not currently in use -->
+    <integer-array name="zero_snooze_durations">
+        <!--<item>1000</item>--><!-- 10sec: 1sec -->
+        <!--<item>5000</item>--><!-- 1min: 5sec -->
+        <item>10000</item><!-- 0:30h: 10sec -->
+        <item>30000</item><!-- 1:00h: 30sec -->
+        <!--<item>10000</item><!- 1:30h: 10sec -->
+        <!--<item>10000</item><!- 2:00h: 10sec -->
+        <!--<item>10000</item><!- 3:00h: 10sec -->
+        <item>10000</item><!-- 6:00h: 10sec -->
+        <!--<item>10000</item><!- 12:00h: 10sec -->
+        <item>10000</item><!-- 24:00h: 10sec -->
+    </integer-array>
+
     <integer-array name="snooze_durations">
         <!--<item>10000</item>--><!-- 10sec -->
         <!--<item>60000</item>--><!-- 1min -->


### PR DESCRIPTION
This would be useful to me as a user of Gadgetbridge and a smart wristband, allowing me to pin a note and then snooze it for 10 seconds so it may post a notification while the screen is off. At that point, I am able to view the pinned note on my wristband, as it should only send notifications when the phone's screen is off.

Features for your consideration, but I don't have the knowledge to complete myself:
 - Auto-snooze on zero snooze duration, or an auto-snooze switch in the UI for any duration
 - Different zero snooze durations for each max snooze duration (already added some values for that)
 - Real Gadgetbridge integration to pin notes on devices deliberately (would require a settings UI)
 - Settings UI button when slider is set to 0 (button changes to cogwheel)